### PR TITLE
remove un-necessary target-path to fix autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "autoload": {
         "psr-0": { "Bitter": "src/" }
     },
-    "target-dir": "FreeAgent/Bitter",
     "config": {
         "bin-dir": "bin"
     }


### PR DESCRIPTION
The autoloading doesn't seem to work. One solution is to remove the un-necessary target-path, the other is to change the autoload configuration... I chose the first option to keep things simple. Hope this is OK.
