### PR TITLE
[Insight] Unused use statement should be avoided

### DIFF
--- a/src/FreeAgent/Bitter/UnitOfTime/AbstractUnitOfTime.php
+++ b/src/FreeAgent/Bitter/UnitOfTime/AbstractUnitOfTime.php
@@ -3,7 +3,6 @@
 namespace FreeAgent\Bitter\UnitOfTime;
 
 use \DateTime;
-use \Exception;
 
 /**
  * @author Jérémy Romey <jeremy@free-agent.fr>


### PR DESCRIPTION
**[in src/FreeAgent/Bitter/UnitOfTime/AbstractUnitOfTime.php, line 6](https://github.com/jeremyFreeAgent/Bitter/blob/master/src/FreeAgent/Bitter/UnitOfTime/AbstractUnitOfTime.php#L6)**
                    > The class `Exception` is declared but never used. You should remove the `use` statement.

```
<?php

namespace FreeAgent\Bitter\UnitOfTime;

use \DateTime;
use \Exception;

/**
 * @author Jérémy Romey <jeremy@free-agent.fr>
 */
abstract class AbstractUnitOfTime
```

_Posted from [SensioLabsInsight](https://insight.sensiolabs.com/projects/d7e4560f-92a1-4f32-a77d-882a9a559956/analyses/2)_
